### PR TITLE
Fix App Tracking Transparency request may fail to show.

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.2.1
+
+* Fixed an issue where App Tracking Transparency prompt may not show correctly on iOS in some situations.
+
 ## 10.2.0
 
 * Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 10.2.0
+version: 10.2.1
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix App Tracking Transparency authorization prompt may fail to show in iOS, due to iOS not showing the prompt unless the app is in an Active state. This often happens when multiple permissions are requested and App Tracking Transparency come after any other authorization prompts.

### :arrow_heading_down: What is the current behavior?
When multiple permissions are requested at once (at client level), and App Tracking Transparency is in the middle of those permissions, the authorization prompt for App Tracking Transparency does not show and the plugin simply return "Denied" as permission authorization state.

### :new: What is the new behavior (if this is a feature change)?
When multiple permissions are requested at once, App Tracking Transparency authorization request will first wait until the app is active again. This would normally happen after the last permission authorization request is dismissed. If the app is already in active state, App Tracking Transparency authorization will be asked immediately.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Use this code on client, and run it on iOS devices.
```dart
Permission.notification.request();
Permission.appTrackingTransparency.request();
```

### :memo: Links to relevant issues/docs
- https://github.com/Baseflow/flutter-permission-handler/issues/676
- https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorizationwith?language=objc

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
